### PR TITLE
Feat/#39: 내 상품 조회

### DIFF
--- a/src/routes/_needAuth/seller/products/index.jsx
+++ b/src/routes/_needAuth/seller/products/index.jsx
@@ -39,77 +39,78 @@ const MOCK_PRODUCTS = [
   },
 ];
 
-/** 상품 한 줄(row) 표시용 컴포넌트 */
-function SellerProductRow({ product }) {
-  const formattedPrice = new Intl.NumberFormat('ko-KR').format(product.price);
-
-  const statusLabelMap = {
-    ACTIVE: '판매 중',
-    PENDING: '승인 대기',
-    SOLD_OUT: '품절',
-    DELETED: '삭제됨',
-  };
-
-  const status = product.status || 'ACTIVE';
-  const statusLabel = statusLabelMap[status] || status;
-  const isSoldOut = status === 'SOLD_OUT' || product.stock === 0;
-
-  return (
-    <div className='grid grid-cols-12 items-center px-4 py-3 text-sm'>
-      <div className='col-span-5 truncate'>
-        <div className='font-medium'>
-          {product.name}
-          {isSoldOut && <span className='ml-2 text-xs text-red-500'>(품절)</span>}
-        </div>
-
-        {product.categoryName && (
-          <div className='text-muted-foreground text-xs'>{product.categoryName}</div>
-        )}
-
-        {product.createdAt && (
-          <div className='text-muted-foreground text-xs'>등록일: {product.createdAt}</div>
-        )}
-      </div>
-
-      <div className='col-span-2 text-right tabular-nums'>{formattedPrice}원</div>
-
-      <div className='col-span-1 text-center tabular-nums'>{product.stock}</div>
-
-      <div className='col-span-2 text-center'>
-        <Badge variant='outline'>{statusLabel}</Badge>
-      </div>
-
-      <div className='col-span-2 flex justify-end gap-2'>
-        <Button
-          asChild
-          variant='outline'
-          size='sm'
-        >
-          <Link
-            to='/seller/products/$productId/edit'
-            params={{ productId: product.id }}
-          >
-            수정
-          </Link>
-        </Button>
-
-        <Button
-          variant='outline'
-          size='sm'
-          disabled
-        >
-          삭제
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 function SellerProductListPage() {
   const products = MOCK_PRODUCTS;
 
   const totalCount = products.length;
   const activeCount = products.filter((p) => p.status === 'ACTIVE').length;
+
+  /** 상품 한 줄(row) 표시용 컴포넌트 */
+  function sellerProductRow({ product }) {
+    const formattedPrice = new Intl.NumberFormat('ko-KR').format(product.price);
+
+    const statusLabelMap = {
+      ACTIVE: '판매 중',
+      PENDING: '승인 대기',
+      SOLD_OUT: '품절',
+      DELETED: '삭제됨',
+    };
+
+    const status = product.status || 'ACTIVE';
+    const statusLabel = statusLabelMap[status] || status;
+    const isSoldOut = status === 'SOLD_OUT' || product.stock === 0;
+
+    return (
+      <div className='grid grid-cols-12 items-center px-4 py-3 text-sm'>
+        <div className='col-span-5 truncate'>
+          <div className='font-medium'>{product.name}</div>
+
+          {product.categoryName && (
+            <div className='text-muted-foreground text-xs'>{product.categoryName}</div>
+          )}
+
+          {product.createdAt && (
+            <div className='text-muted-foreground text-xs'>등록일: {product.createdAt}</div>
+          )}
+        </div>
+
+        <div className='col-span-2 text-right tabular-nums'>{formattedPrice}원</div>
+
+        <div className='col-span-1 text-center tabular-nums'>{product.stock}</div>
+
+        <div className='col-span-2 text-center'>
+          {isSoldOut ? (
+            <Badge variant='destructive'>품절</Badge>
+          ) : (
+            <Badge variant='outline'>{statusLabel}</Badge>
+          )}
+        </div>
+
+        <div className='col-span-2 flex justify-end gap-2'>
+          <Button
+            asChild
+            variant='outline'
+            size='sm'
+          >
+            <Link
+              to='/seller/products/$productId/edit'
+              params={{ productId: product.id }}
+            >
+              수정
+            </Link>
+          </Button>
+
+          <Button
+            variant='outline'
+            size='sm'
+            disabled
+          >
+            삭제
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <main className='font-kakao-big-sans mx-auto max-w-5xl px-4 py-8'>
@@ -179,14 +180,7 @@ function SellerProductListPage() {
         )}
 
         {products.length > 0 && (
-          <div className='divide-y'>
-            {products.map((product) => (
-              <SellerProductRow
-                key={product.id}
-                product={product}
-              />
-            ))}
-          </div>
+          <div className='divide-y'>{products.map((product) => sellerProductRow({ product }))}</div>
         )}
       </section>
     </main>


### PR DESCRIPTION
## PR 내용

- 내 상품 조회 페이지 추가

## 연관 이슈

Resolves #39 

## 변경 사항

- [x] Seller Product List Page
ㄴ /seller/products 경로에 판매자 상품 목록 페이지 추가
ㄴ API 연동 없이 목(Mock) 데이터 기반으로 UI 우선 구현
ㄴ 상품 정보(이름, 가격, 재고, 상태) 표시

- [x] 상품 요약 섹션 추가
ㄴ 전체 상품 수, 판매 중 상품 수, 품절/비활성 수량 조회
ㄴ 대시보드 형태의 카드 UI 구성

- [x] UI/UX 개선
ㄴ 상품 등록 버튼 → /seller/products/new 연결
ㄴ 상태(판매 중, 품절, 승인 대기 등) Badge로 시각화
ㄴ 목록 테이블 레이아웃 구성

## 리뷰 요구사항(Optional)

전체적으로 검토 및 어색하거나 맞지 않는 코드가 있으면 수정 요청 부탁드립니다.
