### PR TITLE
Feat/#51: 회원 권한 관리

### DIFF
--- a/src/routes/_needAuth/_admin/admin/users.jsx
+++ b/src/routes/_needAuth/_admin/admin/users.jsx
@@ -10,7 +10,13 @@ import {
 import { Fragment, useState, useEffect } from 'react';
 import { adminApi } from '@/api/adminApi';
 import { Button } from '@/components/ui/button';
-
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select';
 export const Route = createFileRoute('/_needAuth/_admin/admin/users')({
   component: RouteComponent,
 });
@@ -18,7 +24,7 @@ export const Route = createFileRoute('/_needAuth/_admin/admin/users')({
 /** 선택 가능한 권한 옵션 */
 const ROLE_OPTIONS = [
   { value: 'USER', label: '일반 회원' },
-  { value: 'RSELLER', label: '판매자' },
+  { value: 'SELLER', label: '판매자' },
   { value: 'ADMIN', label: '관리자' },
 ];
 
@@ -169,22 +175,27 @@ function RouteComponent() {
                                 변경할 권한을 선택하세요.
                               </label>
 
-                              <select
-                                value={currentDraftRole}
-                                onChange={(e) =>
-                                  handleRoleSelectChange(user.userId, e.target.value)
+                              <Select
+                                defaultValue={currentDraftRole}
+                                onValueChange={(value) =>
+                                  handleRoleSelectChange(user.userId, value)
                                 }
-                                className='h-8 rounded border px-2 text-xs'
                               >
-                                {ROLE_OPTIONS.map((role) => (
-                                  <option
-                                    key={role.value}
-                                    value={role.value}
-                                  >
-                                    {role.label} ({role.value})
-                                  </option>
-                                ))}
-                              </select>
+                                <SelectTrigger className='h-8 w-[160px] text-xs'>
+                                  <SelectValue placeholder='권한 선택' />
+                                </SelectTrigger>
+
+                                <SelectContent>
+                                  {ROLE_OPTIONS.map((role) => (
+                                    <SelectItem
+                                      key={role.value}
+                                      value={role.value}
+                                    >
+                                      {role.label} ({role.value})
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
 
                               <Button
                                 type='button'
@@ -215,3 +226,5 @@ function RouteComponent() {
     </>
   );
 }
+
+export default RouteComponent;


### PR DESCRIPTION
## PR 내용

- 회원 권한 관리 기능 추가

## 연관 이슈

Resolves #51 

## 변경 사항

- [x] 회원 관리 페이지 확장 영역에 권한 관리 섹션 추가
ㄴ `/src/routes/_needAuth/_admin/admin/users.jsx` 내에서 행 클릭 시 상세 정보가 펼쳐질 때, 함께 권한 변경 UI가 나타나도록 구성했습니다.

- [x] 권한 선택 옵션 및 드롭다운 기능
ㄴ `ROLE_OPTIONS` 상수를 추가하여 `USER / RSELLER / ADMIN` 세 가지 권한 타입을 드롭다운에서 선택할 수 있도록 구현했습니다.
ㄴ `roleDrafts` 상태를 도입하여 `userId` 기준으로 변경 예정 권한 값을 관리합니다.
ㄴ 현재 회원의 권한과 선택된 권한이 동일할 경우, "권한 변경" 버튼이 비활성화되도록 처리했습니다.

- [x] 권한 변경 적용 로직 (프론트 상태 기준)
ㄴ `handleApplyRoleChange` 함수에서 선택된 권한 값이 있을 경우, `users` 상태에서 해당 회원의 `userRole`을 갱신하도록 구현했습니다.
ㄴ 임시로 `updatedAt` 필드를 `new Date().toISOString()` 기준으로 갱신하여 화면에서 최근 수정일이 변경되는 것을 확인할 수 있습니다.
ㄴ 아직 실제 관리자 권한 변경 API는 연동하지 않았으며, 추후 `adminApi` 기반 PATCH 연동을 추가할 수 있도록 try-catch 구조를 남겨두었습니다.

## 리뷰 요구사항(Optional)

전체적으로 검토 및 어색하거나 맞지 않는 코드가 있으면 수정 요청 부탁드립니다.
