### PR TITLE
Feat: #22 Add mypage profile page

### DIFF
--- a/src/components/profile/ProfileInfo.jsx
+++ b/src/components/profile/ProfileInfo.jsx
@@ -1,0 +1,93 @@
+// src/components/profile/ProfileInfo.jsx
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+import { Separator } from '@/components/ui/separator';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '../ui/button';
+import { Link } from '@tanstack/react-router';
+
+function formatPhone(phone) {
+  if (!phone) return '-';
+
+  const digits = phone.replace(/\D/g, '');
+
+  if (digits.length === 11) {
+    return digits.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+  }
+
+  return phone;
+}
+
+export default function ProfileInfo({ data }) {
+  const { userName, userEmail, userPhone, userNickname, userRole, createdAt } = data;
+
+  const showRole = userRole === 'SELLER' || userRole === 'ADMIN';
+
+  return (
+    <Card className='mx-auto w-full max-w-3xl'>
+      <CardHeader>
+        <CardTitle className='text-lg font-semibold'>내 프로필</CardTitle>
+      </CardHeader>
+
+      <CardContent className='space-y-4'>
+        <InfoRow
+          label='이름'
+          value={userName}
+        />
+        <Separator />
+
+        <InfoRow
+          label='이메일'
+          value={userEmail}
+        />
+        <Separator />
+
+        <InfoRow
+          label='연락처'
+          value={formatPhone(userPhone)}
+        />
+        <Separator />
+
+        <InfoRow
+          label='닉네임'
+          value={userNickname}
+        />
+        <Separator />
+
+        {showRole && (
+          <>
+            <div className='flex items-center justify-between'>
+              <span className='font-semibold'>권한</span>
+              <Badge variant='secondary'>{userRole}</Badge>
+            </div>
+            <Separator />
+          </>
+        )}
+
+        <InfoRow
+          label='가입일'
+          value={createdAt?.slice(0, 10)}
+        />
+
+        <Button
+          asChild
+          variant='outline'
+          className='mt-5 w-full'
+          size='sm'
+        >
+          <Link to='/mypage/editProfile'>프로필 수정</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function InfoRow({ label, value }) {
+  return (
+    <div className='flex items-center justify-between py-3'>
+      <span className='font-semibold'>{label}</span>
+      <span>{value || '-'}</span>
+    </div>
+  );
+}

--- a/src/routes/_needAuth/_mypage/mypage.jsx
+++ b/src/routes/_needAuth/_mypage/mypage.jsx
@@ -15,10 +15,11 @@ function RouteComponent() {
   */
   const menuItems = [
     { label: '회원 정보', path: '/mypage' },
+    { label: '내 프로필', path: '/mypage/profile' },
+    { label: '회원 정보 수정', path: '/mypage/editProfile' },
     { label: '주문 내역', path: '/mypage/order' },
     { label: '접근성 프로필', path: '/mypage/a11y' },
     { label: '배송지 관리', path: '/mypage/address' },
-    { label: '회원 정보 수정', path: '/mypage/editProfile' },
   ];
 
   // 내비게이션 경로 표시 상단바

--- a/src/routes/_needAuth/_mypage/mypage/profile.jsx
+++ b/src/routes/_needAuth/_mypage/mypage/profile.jsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+import { userApi } from '@/api/userApi';
+import ProfileInfo from '@/components/profile/ProfileInfo';
+import { Card, CardContent } from '@/components/ui/card';
+
+export const Route = createFileRoute('/_needAuth/_mypage/mypage/profile')({
+  component: ProfilePage,
+});
+
+function ProfilePage() {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    userApi
+      .getProfile()
+      .then((res) => setProfile(res.data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <Card className='mx-auto mt-6 w-full max-w-xl'>
+        <CardContent className='p-6'>불러오는 중...</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className='p-4'>
+      <ProfileInfo data={profile} />
+    </div>
+  );
+}


### PR DESCRIPTION
## PR 내용

- 마이페이지의 내 프로필 조회 페이지 추가

## 연관 이슈

Resolves #22 

## 변경 사항
- [x] _needAuth/_mypage/mypage/profile.jsx 생성 : 내 프로필 조회 페이지 추가

- [x] components/profile/ProfileInfo.jsx 생성
ㄴ 계정 정보 조회 UI 구현
ㄴ 카드 하단에 프로필 수정 버튼 추가 : /mypage/editProfile 페이지로 이동

- [x] mypage.jsx 수정 : 내 프로필 서브메뉴(label) 추가


## 스크린샷(Optional)

<img width="1191" height="897" alt="image" src="https://github.com/user-attachments/assets/392a76b9-92a3-45e0-962c-38732cf107d7" />
