### PR TITLE
refactor: rename a11y contrast & fix preset apply

### DIFF
--- a/src/components/accessibility/a11y-overlay.jsx
+++ b/src/components/accessibility/a11y-overlay.jsx
@@ -108,7 +108,7 @@ export default function A11yOverlay({ open, onClose, reloadProfiles }) {
   const iconSize = 'size-10';
   const boxBase =
     'relative flex flex-col items-center justify-center gap-2 rounded-xl border bg-gray-100 px-4 py-20 text-sm cursor-pointer focus:outline-none focus:ring-0 focus:ring-offset-0';
-  const contrastLabels = ['기본 대비', '색 반전', '다크', '라이트'];
+  const contrastLabels = ['기본 대비', '색 반전', '고대비', '저대비'];
 
   return (
     <Sheet
@@ -199,6 +199,8 @@ export default function A11yOverlay({ open, onClose, reloadProfiles }) {
                     onValueChange={(modeId) => {
                       setSelectedSubMode(modeId);
 
+                      dispatch(resetAll());
+                      
                       const selectedMode = A11Y_PROFILES[selectedProfile].items.find(
                         (item) => item.id === modeId,
                       );


### PR DESCRIPTION
## PR 내용

- 접근성 오버레이의 버튼 이름 변경 및 세부모드 중복적용 수정

## 연관 이슈

Reference #71

## 변경 사항

- [x] 대비 버튼의 이름 변경 : 다크 -> 고대비 / 라이트 -> 저대비
- [x] 접근성 프로필 프리셋 적용시 중복 적용되는 문제 수정

